### PR TITLE
Fix typecheck errors introduced while adapting tests

### DIFF
--- a/tests/frontier/precompiles/test_precompiles.py
+++ b/tests/frontier/precompiles/test_precompiles.py
@@ -36,12 +36,10 @@ def precompile_addresses(fork: Fork) -> Iterator[Tuple[Address, bool]]:
         address_int = int.from_bytes(address, byteorder="big")
         yield (address, True)
         if address_int > 0 and (address_int - 1) not in supported_precompiles:
-            # yield (Address(address_int - 1), False)
-            yield pytest.param(Address(address_int - 1), False, marks=pytest.mark.xfail(reason="Calls to Hedera reserved accounts causes gas consumption differences https://github.com/gkozyryatskyy/execution-spec-tests/issues/25"))
+            yield (Address(address_int - 1), False)
 
         if (address_int + 1) not in supported_precompiles:
-            # yield (Address(address_int + 1), False)
-            yield pytest.param(Address(address_int + 1), False, marks=pytest.mark.xfail(reason="Calls to Hedera reserved accounts causes gas consumption differences https://github.com/gkozyryatskyy/execution-spec-tests/issues/25"))
+            yield (Address(address_int + 1), False)
 
 
 @pytest.mark.ported_from(
@@ -80,6 +78,9 @@ def test_precompiles(
     precompiled contract exists at the given address.
 
     """
+    if not precompile_exists:
+        pytest.skip(reason="Calls to Hedera reserved accounts causes gas consumption differences https://github.com/gkozyryatskyy/execution-spec-tests/issues/25")
+
     env = Environment()
 
     # Empty account to serve as reference

--- a/tests/frontier/scenarios/test_scenarios.py
+++ b/tests/frontier/scenarios/test_scenarios.py
@@ -235,7 +235,7 @@ def test_scenarios(
             # This is because the default coinbase in Hedera is account `0x0000000000000000000000000000000000000062`.
             # https://github.com/gkozyryatskyy/execution-spec-tests/issues/28
             # coinbase=tx_env.fee_recipient,
-            coinbase="0x0000000000000000000000000000000000000062",
+            coinbase=Address("0x0000000000000000000000000000000000000062"),
         )
 
         def make_result(scenario: Scenario, exec_env: ExecutionEnvironment, post: Storage) -> int:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
