### PR TITLE
Fix formatting to avoid CI failure

### DIFF
--- a/src/ethereum_test_rpc/rpc_types.py
+++ b/src/ethereum_test_rpc/rpc_types.py
@@ -88,9 +88,10 @@ class TransactionByHashResponse(Transaction):
         #  - https://github.com/hiero-ledger/hiero-json-rpc-relay/issues/4436
         # assert self.transaction_hash == self.hash
         if self.transaction_hash == self.hash:
-            print(f"Transaction hash {self.transaction_hash} matches hash calculated from the RLP transaction data")
+            print(f"Tx hash {self.transaction_hash} matches hash from RLP data")
         else:
-            print(f"Transaction hash {self.transaction_hash} does not match hash calculated from the RLP transaction data {self.hash}")
+            print(f"Tx hash {self.transaction_hash} doesn't match hash from RLP data {self.hash}")
+
 
 class ForkchoiceState(CamelModel):
     """Represents the forkchoice state of the beacon chain."""

--- a/src/ethereum_test_types/transaction_types.py
+++ b/src/ethereum_test_types/transaction_types.py
@@ -319,9 +319,9 @@ class Transaction(
         # NOTICE Transaction value needs to be scaled up by `TINYBAR_TO_WEIBAR`
         # due to differences in decimal precision between Hedera and Ethereum.
         # https://github.com/gkozyryatskyy/execution-spec-tests/issues/17
-        TINYBAR_TO_WEIBAR = 10_000_000_000
-        if 0 < self.value < TINYBAR_TO_WEIBAR:
-            self.value = self.value * TINYBAR_TO_WEIBAR
+        tinybar_to_weibar = 10_000_000_000
+        if 0 < self.value < tinybar_to_weibar:
+            self.value = self.value * tinybar_to_weibar
             print(f"[DEBUG] Transaction value {self.value} scaled by `TINYBAR_TO_WEIBAR`")
 
         if self.gas_price is not None and (
@@ -359,7 +359,7 @@ class Transaction(
         # Set default values for fields that are required for certain tx types
         if self.ty <= 1 and self.gas_price is None:
             self.gas_price = TransactionDefaults.gas_price
-        # NOTICE Sending access list is currently not supported due to an issue in the Relay/SDK
+        # NOTICE Sending access list is currently not supported
         # https://github.com/gkozyryatskyy/execution-spec-tests/issues/6
         # if self.ty >= 1: and self.access_list is None:
         if self.ty >= 1:
@@ -367,13 +367,13 @@ class Transaction(
         if self.ty < 1:
             assert self.access_list is None, "access_list must be None"
 
-        # NOTICE Gas price needs to be at least `71 * TINYBAR_TO_WEIBAR` otherwise
+        # NOTICE Gas price needs to be at least 71*tinybar_to_weibar otherwise
         # the JSON-RPC Relay rejects the transaction.
         # https://github.com/gkozyryatskyy/execution-spec-tests/issues/16
-        MIN_GAS_PRICE = 71 * TINYBAR_TO_WEIBAR
-        if not self.gas_price is None and self.gas_price < MIN_GAS_PRICE:
-            self.gas_price += MIN_GAS_PRICE
-            print(f"[DEBUG] Adjusted gas_price {self.gas_price }")
+        min_gas_price = 71 * tinybar_to_weibar
+        if self.gas_price is not None and self.gas_price < min_gas_price:
+            self.gas_price += min_gas_price
+            print(f"[DEBUG] Adjusted gas_price {self.gas_price}")
 
         if self.ty >= 2 and self.max_fee_per_gas is None:
             self.max_fee_per_gas = TransactionDefaults.max_fee_per_gas
@@ -383,9 +383,9 @@ class Transaction(
             assert self.max_fee_per_gas is None, "max_fee_per_gas must be None"
             assert self.max_priority_fee_per_gas is None, "max_priority_fee_per_gas must be None"
 
-        if not self.max_fee_per_gas is None and self.max_fee_per_gas < MIN_GAS_PRICE:
-            self.max_fee_per_gas = MIN_GAS_PRICE
-            print(f"[DEBUG] Adjusted max_fee_per_gas {self.max_fee_per_gas }")
+        if self.max_fee_per_gas is not None and self.max_fee_per_gas < min_gas_price:
+            self.max_fee_per_gas = min_gas_price
+            print(f"[DEBUG] Adjusted max_fee_per_gas {self.max_fee_per_gas}")
 
         if self.ty == 3 and self.max_fee_per_blob_gas is None:
             self.max_fee_per_blob_gas = 1

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode_contexts.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode_contexts.py
@@ -165,7 +165,7 @@ def simple_blob_hashes(
     ],
     ids=lambda x: x,
 )
-@pytest.mark.skip(reason="Unable to run test due to AssertionError: Transaction type 3 is not supported in execute mode https://github.com/gkozyryatskyy/execution-spec-tests/issues/21")
+@pytest.mark.skip(reason="Tx type 3 not supported gkozyryatskyy/execution-spec-tests/issues/21")
 def test_blobhash_opcode_contexts(
     pre: Alloc,
     test_case: str,

--- a/tests/frontier/identity_precompile/test_identity.py
+++ b/tests/frontier/identity_precompile/test_identity.py
@@ -63,7 +63,9 @@ from .common import CallArgs, generate_identity_call_bytecode
             0x1,
             True,
             id="identity_1_nonzerovalue",
-            marks=pytest.mark.skip(reason="Value transfer to identity precompile is not supported https://github.com/gkozyryatskyy/execution-spec-tests/issues/12"),
+            marks=pytest.mark.skip(
+                reason="Value transfer to identity precompile is not supported https://github.com/gkozyryatskyy/execution-spec-tests/issues/12"
+            ),
         ),
         pytest.param(
             CallArgs(gas=0x30D40, value=0x1, args_size=0x0),

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -54,7 +54,7 @@ def prepare_suffix(opcode: Opcode) -> Bytecode:
     pr=["https://github.com/ethereum/execution-spec-tests/pull/748"],
 )
 @pytest.mark.valid_from("Frontier")
-@pytest.mark.xfail(reason="`CALL` and `CALLCODE` contracts make the whole transaction fail because they send a non-zero value to precompile 0x1 https://github.com/gkozyryatskyy/execution-spec-tests/issues/12")
+@pytest.mark.xfail(reason="https://github.com/gkozyryatskyy/execution-spec-tests/issues/12")
 def test_all_opcodes(state_test: StateTestFiller, pre: Alloc, fork: Fork):
     """
     Test each possible opcode on the fork with a single contract that calls
@@ -111,7 +111,7 @@ def test_all_opcodes(state_test: StateTestFiller, pre: Alloc, fork: Fork):
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.xfail(reason="`eth_getTransactionByHash` does not include a `to` field for contract creation txs that reverts https://github.com/gkozyryatskyy/execution-spec-tests/issues/4")
+@pytest.mark.xfail(reason="https://github.com/gkozyryatskyy/execution-spec-tests/issues/4")
 def test_cover_revert(state_test: StateTestFiller, pre: Alloc):
     """Cover state revert from original tests for the coverage script."""
     tx = Transaction(

--- a/tests/frontier/precompiles/test_precompiles.py
+++ b/tests/frontier/precompiles/test_precompiles.py
@@ -78,7 +78,9 @@ def test_precompiles(
 
     """
     if not precompile_exists:
-        pytest.skip(reason="Calls to Hedera reserved accounts causes gas consumption differences https://github.com/gkozyryatskyy/execution-spec-tests/issues/25")
+        pytest.skip(
+            reason="Calls to Hedera reserved accounts causes gas consumption differences https://github.com/gkozyryatskyy/execution-spec-tests/issues/25"
+        )
 
     env = Environment()
 

--- a/tests/frontier/scenarios/test_scenarios.py
+++ b/tests/frontier/scenarios/test_scenarios.py
@@ -143,7 +143,9 @@ def scenarios(fork: Fork, pre: Alloc, test_program: ScenarioTestProgram) -> List
         ProgramSstoreSload(),
         ProgramTstoreTload(),
         ProgramLogs(),
-        pytest.param(ProgramSuicide(), marks=pytest.mark.skip(reason="Do we support `SELFDESTRUCT` in these scenarios? https://github.com/gkozyryatskyy/execution-spec-tests/issues/5")),
+        pytest.param(
+            ProgramSuicide(), marks=pytest.mark.skip(reason="Do we support `SELFDESTRUCT`?")
+        ),
         ProgramInvalidOpcode(),
         ProgramAddress(),
         ProgramBalance(),
@@ -162,7 +164,7 @@ def scenarios(fork: Fork, pre: Alloc, test_program: ScenarioTestProgram) -> List
         ProgramBlockhash(),
         ProgramCoinbase(),
         ProgramTimestamp(),
-        pytest.param(ProgramNumber(), marks=pytest.mark.skip(reason="It compares network's current block number against hardcoded value 1 https://github.com/gkozyryatskyy/execution-spec-tests/issues/26")),
+        pytest.param(ProgramNumber(), marks=pytest.mark.skip(reason="Compares block number to 1")),
         ProgramDifficultyRandao(),
         ProgramGasLimit(),
         ProgramChainid(),
@@ -224,15 +226,14 @@ def test_scenarios(
             timestamp=tx_env.timestamp,  # we can't know timestamp before head,
             # use gas hash
             number=len(blocks) + 1,
-
             # NOTICE The `gaslimit` needs to be adjusted for `ProgramGasLimit`.
-            # This is because it needs to match the `gas_limit` in the transaction sent.
+            # This is because it needs to match the `gas_limit` in the tx sent.
             # https://github.com/gkozyryatskyy/execution-spec-tests/issues/27
             # gaslimit=tx_env.gas_limit,
             gaslimit=tx_max_gas + 100_000,
-
             # NOTICE The `coinbase` needs to be adjusted for `ProgramCoinbase`.
-            # This is because the default coinbase in Hedera is account `0x0000000000000000000000000000000000000062`.
+            # This is because the default coinbase in Hedera is
+            # account `0x0000000000000000000000000000000000000062`.
             # https://github.com/gkozyryatskyy/execution-spec-tests/issues/28
             # coinbase=tx_env.fee_recipient,
             coinbase=Address("0x0000000000000000000000000000000000000062"),

--- a/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
+++ b/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
@@ -28,15 +28,14 @@ REFERENCE_SPEC_VERSION = ref_spec_3651.version
 # Amount of gas required to make a call to a warm account.
 # Calling a cold account with this amount of gas results in exception.
 
-# `COINBASE` address `0x0000000000000000000000000000000000000062` is not warm at the start of the transaction.
-# See https://github.com/gkozyryatskyy/execution-spec-tests/issues/9 for more details.
+# `COINBASE` `0x0000000000000000000000000000000000000062` is not callable-warm.
+# https://github.com/gkozyryatskyy/execution-spec-tests/issues/9
 # https://docs.hedera.com/hedera/core-concepts/smart-contracts/gas-and-fees#gas-limit
 # However, the tests pass if we treat `COINBASE` as a cold address instead.
 # GAS_REQUIRED_CALL_WARM_ACCOUNT = 100
 GAS_REQUIRED_CALL_WARM_ACCOUNT = 2600
 
 
-# @pytest.mark.skip(reason="Seems like Hedera blocking sys-address (COINBASE) from calling. Skipping for now")
 @pytest.mark.valid_from("Shanghai")
 @pytest.mark.parametrize(
     "use_sufficient_gas",
@@ -136,10 +135,12 @@ def test_warm_coinbase_call_out_of_gas(
         tag="opcode_" + opcode,
     )
 
-# The amount of gas sent to the `COINBASE` calls (`CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`)
-# is consumed as well. So we need to take it into account when calculating the `overhead_cost`.
+
+# The amount of gas sent to the `COINBASE` calls,
+# `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, is consumed as well.
+# So we need to take it into account when calculating the `overhead_cost`.
 # Originally, the gas sent was `0xFF` but it has to be reduced to `0x7F`.
-# This is to ensure that the gas sent plus the already existing `overhead_cost` fit in a `PUSH1` opcode.
+# This ensures the gas sent plus the `overhead_cost` fit in a `PUSH1` opcode.
 EXTRA_GAS = 0x7F
 
 # List of opcodes that are affected by EIP-3651
@@ -209,7 +210,7 @@ gas_measured_opcodes = [
     ),
 ]
 
-# @pytest.mark.skip(reason="Seems like Hedera blocking sys-address (COINBASE) from calling. Skipping for now")
+
 @pytest.mark.valid_from("Berlin")  # these tests fill for fork >= Berlin
 @pytest.mark.parametrize(
     "opcode,code_gas_measure",

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -211,8 +211,9 @@ def valid_gas_test_case(initcode: Initcode, gas_test_case: str) -> bool:
         return (initcode.deployment_gas + initcode.execution_gas) > 0
     return True
 
-# TODO Glib:
-#  - this https://github.com/hyperledger/besu/pull/8817/files can be relared of gas difference
+
+# TODO Glib: this can be related to gas difference
+# https://github.com/hyperledger/besu/pull/8817/files
 @pytest.mark.parametrize(
     "initcode,gas_test_case",
     [
@@ -222,14 +223,23 @@ def valid_gas_test_case(initcode: Initcode, gas_test_case: str) -> bool:
             marks=([pytest.mark.exception_test] if g == "too_little_intrinsic_gas" else []),
         )
         for i in [
-            INITCODE_ZEROS_MAX_LIMIT, # TODO Glib: Hedera: 249740,249940 / Tests(int,exec): 252788,253012 / Diff 3048,3072
-            INITCODE_ONES_MAX_LIMIT, # TODO Glib: Hedera: 839420,839620 / Tests(int,exec): 842468,842692 / Diff 3048,3072
-            # EMPTY_INITCODE, # TODO Glib: Hedera: INVALID_ETHEREUM_TRANSACTION / Tests: 53000,53000 / Possible surce: https://github.com/hiero-ledger/hiero-consensus-node/blob/main/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java#L279
-            SINGLE_BYTE_INITCODE, # TODO Glib: Success
-            INITCODE_ZEROS_32_BYTES, # TODO Glib: Hedera(consumed,used): 53260,53460 / Tests(int,exec): 53238,53462 / Diff -22,2
-            INITCODE_ZEROS_33_BYTES, # TODO Glib: Hedera(consumed,used): 53264,53464 / Tests(int,exec): 53244,53468 / Diff -20,4
-            INITCODE_ZEROS_49120_BYTES, # TODO Glib: Hedera: 249612,249812 / Tests(int,exec): 252658,252882 / Diff 3046,3070
-            INITCODE_ZEROS_49121_BYTES, # TODO Glib: Hedera: 249616,249816 / Tests(int,exec): 252664,252888 / Diff 3046,3070
+            # Glib: 249740,249940/Tests(int,exec): 252788,253012/Diff 3048,3072
+            INITCODE_ZEROS_MAX_LIMIT,
+            # Glib: 839420,839620 / Tests: 842468,842692/Diff 3048,3072
+            INITCODE_ONES_MAX_LIMIT,
+            # Glib: INVALID_ETHEREUM_TRANSACTION/Tests: 53000,53000 see
+            # https://github.com/hiero-ledger/hiero-consensus-node/blob/main/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java#L279
+            # EMPTY_INITCODE,
+            # TODO Glib: Success
+            SINGLE_BYTE_INITCODE,
+            # Glib: (consumed,used): 53260,53460/Tests: 53238,53462/Diff -22,2
+            INITCODE_ZEROS_32_BYTES,
+            # Glib: (consumed,used): 53264,53464/Tests: 53244,53468/Diff -20,4
+            INITCODE_ZEROS_33_BYTES,
+            # Glib: 249612,249812 / Tests: 252658,252882/Diff 3046,3070
+            INITCODE_ZEROS_49120_BYTES,
+            # Glib: 249616,249816 / Tests: 252664,252888/Diff 3046,3070
+            INITCODE_ZEROS_49121_BYTES,
         ]
         for g in [
             # "too_little_intrinsic_gas",


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
