### PR TITLE
Restore and skip `gaslimit` scenario test

### DIFF
--- a/tests/frontier/scenarios/test_scenarios.py
+++ b/tests/frontier/scenarios/test_scenarios.py
@@ -144,7 +144,10 @@ def scenarios(fork: Fork, pre: Alloc, test_program: ScenarioTestProgram) -> List
         ProgramTstoreTload(),
         ProgramLogs(),
         pytest.param(
-            ProgramSuicide(), marks=pytest.mark.skip(reason="Do we support `SELFDESTRUCT`?")
+            ProgramSuicide(),
+            marks=pytest.mark.skip(
+                reason="`SELFDESTRUCT` causes `FAIL_INVALID` error in these scenarios https://github.com/gkozyryatskyy/execution-spec-tests/issues/5"
+            ),
         ),
         ProgramInvalidOpcode(),
         ProgramAddress(),
@@ -164,9 +167,19 @@ def scenarios(fork: Fork, pre: Alloc, test_program: ScenarioTestProgram) -> List
         ProgramBlockhash(),
         ProgramCoinbase(),
         ProgramTimestamp(),
-        pytest.param(ProgramNumber(), marks=pytest.mark.skip(reason="Compares block number to 1")),
+        pytest.param(
+            ProgramNumber(),
+            marks=pytest.mark.skip(
+                reason="Compares block number to 1 https://github.com/gkozyryatskyy/execution-spec-tests/issues/26"
+            ),
+        ),
         ProgramDifficultyRandao(),
-        ProgramGasLimit(),
+        pytest.param(
+            ProgramGasLimit(),
+            marks=pytest.mark.skip(
+                reason="The `gaslimit` opcode needs to be revisited https://github.com/gkozyryatskyy/execution-spec-tests/issues/27"
+            ),
+        ),
         ProgramChainid(),
         ProgramSelfbalance(),
         ProgramBasefee(),
@@ -226,11 +239,7 @@ def test_scenarios(
             timestamp=tx_env.timestamp,  # we can't know timestamp before head,
             # use gas hash
             number=len(blocks) + 1,
-            # NOTICE The `gaslimit` needs to be adjusted for `ProgramGasLimit`.
-            # This is because it needs to match the `gas_limit` in the tx sent.
-            # https://github.com/gkozyryatskyy/execution-spec-tests/issues/27
-            # gaslimit=tx_env.gas_limit,
-            gaslimit=tx_max_gas + 100_000,
+            gaslimit=tx_env.gas_limit,
             # NOTICE The `coinbase` needs to be adjusted for `ProgramCoinbase`.
             # This is because the default coinbase in Hedera is
             # account `0x0000000000000000000000000000000000000062`.


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

This PR restores and skips the `gaslimit` scenario test because after further investigation we realized there was an issue with the `gaslimit` opcode that needs to be fixed.

That means that the test doesn't need to be modified and must be restored.

Additionally, it includes issue references and improves description in the other tests that were also skipped.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Related to https://github.com/gkozyryatskyy/execution-spec-tests/issues/27.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
