### PR TITLE
Restore failing test using fix from Relay >= 0.73

### DIFF
--- a/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -33,7 +33,6 @@ addopts =
     # tests/frontier/identity_precompile/test_identity.py
     #
     # - Precompiles receiving HBARs https://github.com/gkozyryatskyy/execution-spec-tests/issues/12
-    # - Transaction sets `to:0x` and reverts, Relay doesn't have a `to` field in the response of `eth_getTransactionByHash` https://github.com/gkozyryatskyy/execution-spec-tests/issues/4
     # tests/frontier/opcodes/test_all_opcodes.py
     #
     # - Uses `BLOCKHASH(0)` which is not supported in long-lived networks

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -54,7 +54,7 @@ def prepare_suffix(opcode: Opcode) -> Bytecode:
     pr=["https://github.com/ethereum/execution-spec-tests/pull/748"],
 )
 @pytest.mark.valid_from("Frontier")
-@pytest.mark.xfail(reason="https://github.com/gkozyryatskyy/execution-spec-tests/issues/12")
+@pytest.mark.skip(reason="https://github.com/gkozyryatskyy/execution-spec-tests/issues/12")
 def test_all_opcodes(state_test: StateTestFiller, pre: Alloc, fork: Fork):
     """
     Test each possible opcode on the fork with a single contract that calls
@@ -111,7 +111,6 @@ def test_all_opcodes(state_test: StateTestFiller, pre: Alloc, fork: Fork):
 
 
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.xfail(reason="https://github.com/gkozyryatskyy/execution-spec-tests/issues/4")
 def test_cover_revert(state_test: StateTestFiller, pre: Alloc):
     """Cover state revert from original tests for the coverage script."""
     tx = Transaction(


### PR DESCRIPTION
## 🗒️ Description

Test was fixed in https://github.com/hiero-ledger/hiero-json-rpc-relay/issues/4413. Confirmed test passes with this new version of the Relay.

Fixes #4.

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
