### PR TITLE
Enable Berlin tests sending empty ACLs

### DIFF
--- a/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/src/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -50,8 +50,8 @@ addopts =
     # Raises internal error at `pre.deploy_contract`: 'initcode prefix too long' but this test can be safely skipped https://github.com/gkozyryatskyy/execution-spec-tests/issues/22
     --ignore tests/frontier/precompiles/test_precompile_absence.py
 
-    # Access list is not yet supported in the JSON-RPC Relay https://github.com/gkozyryatskyy/execution-spec-tests/issues/6
-    --ignore tests/berlin/eip2930_access_list/
+    # Access lists are not yet supported in the JSON-RPC Relay https://github.com/gkozyryatskyy/execution-spec-tests/issues/6
+    # tests/berlin/eip2930_access_list/
 
     # `SELFDESTRUCT`ing a contract with funds is not supported in Hedera https://github.com/gkozyryatskyy/execution-spec-tests/issues/29
     --ignore tests/paris/security/test_selfdestruct_balance_bug.py

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -24,6 +24,8 @@ REFERENCE_SPEC_VERSION = "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"
 
 pytestmark = pytest.mark.valid_from("Berlin")
 
+TINYBAR_TO_WEIBAR_COEF = 10_000_000_000
+
 aclSkipReason = "Access lists are not yet supported in the JSON-RPC Relay https://github.com/gkozyryatskyy/execution-spec-tests/issues/6"
 
 
@@ -259,7 +261,7 @@ def test_transaction_intrinsic_gas_cost(
 
     post = {
         contract_address: Account(
-            balance=(contract_start_balance + 1 if enough_gas else contract_start_balance) * 10_000_000_000,
+            balance=(contract_start_balance + 1 if enough_gas else contract_start_balance) * TINYBAR_TO_WEIBAR_COEF,
             nonce=1,
         ),
         sender: Account(

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -24,6 +24,8 @@ REFERENCE_SPEC_VERSION = "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"
 
 pytestmark = pytest.mark.valid_from("Berlin")
 
+aclSkipReason = "Access lists are not yet supported in the JSON-RPC Relay https://github.com/gkozyryatskyy/execution-spec-tests/issues/6"
+
 
 @pytest.mark.parametrize(
     "account_warm,storage_key_warm",
@@ -34,6 +36,7 @@ pytestmark = pytest.mark.valid_from("Berlin")
         (False, False),
     ],
 )
+@pytest.mark.skip(reason=aclSkipReason)
 def test_account_storage_warm_cold_state(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -124,14 +127,17 @@ def test_account_storage_warm_cold_state(
         pytest.param(
             [AccessList(address=Address(0), storage_keys=[])],
             id="single_address_multiple_no_storage_keys",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [AccessList(address=Address(0), storage_keys=[Hash(0)])],
             id="single_address_single_storage_key",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [AccessList(address=Address(0), storage_keys=[Hash(0), Hash(1)])],
             id="single_address_multiple_storage_keys",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [
@@ -139,6 +145,7 @@ def test_account_storage_warm_cold_state(
                 AccessList(address=Address(1), storage_keys=[]),
             ],
             id="multiple_addresses_second_address_no_storage_keys",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [
@@ -146,6 +153,7 @@ def test_account_storage_warm_cold_state(
                 AccessList(address=Address(1), storage_keys=[Hash(0)]),
             ],
             id="multiple_addresses_second_address_single_storage_key",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [
@@ -153,6 +161,7 @@ def test_account_storage_warm_cold_state(
                 AccessList(address=Address(1), storage_keys=[Hash(0), Hash(1)]),
             ],
             id="multiple_addresses_second_address_multiple_storage_keys",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [
@@ -160,6 +169,7 @@ def test_account_storage_warm_cold_state(
                 AccessList(address=Address(1), storage_keys=[Hash(0), Hash(1)]),
             ],
             id="multiple_addresses_first_address_no_storage_keys",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [
@@ -167,6 +177,7 @@ def test_account_storage_warm_cold_state(
                 AccessList(address=Address(1), storage_keys=[Hash(0), Hash(1)]),
             ],
             id="multiple_addresses_first_address_single_storage_key",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [
@@ -174,6 +185,7 @@ def test_account_storage_warm_cold_state(
                 AccessList(address=Address(1), storage_keys=[]),
             ],
             id="repeated_address_no_storage_keys",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [
@@ -181,6 +193,7 @@ def test_account_storage_warm_cold_state(
                 AccessList(address=Address(0), storage_keys=[Hash(1)]),
             ],
             id="repeated_address_single_storage_key",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
         pytest.param(
             [
@@ -188,6 +201,7 @@ def test_account_storage_warm_cold_state(
                 AccessList(address=Address(0), storage_keys=[Hash(0), Hash(1)]),
             ],
             id="repeated_address_multiple_storage_keys",
+            marks=pytest.mark.skip(reason=aclSkipReason),
         ),
     ],
 )
@@ -245,7 +259,7 @@ def test_transaction_intrinsic_gas_cost(
 
     post = {
         contract_address: Account(
-            balance=contract_start_balance + 1 if enough_gas else contract_start_balance,
+            balance=(contract_start_balance + 1 if enough_gas else contract_start_balance) * 10_000_000_000,
             nonce=1,
         ),
         sender: Account(
@@ -255,6 +269,7 @@ def test_transaction_intrinsic_gas_cost(
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.skip(reason=aclSkipReason)
 def test_repeated_address_acl(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py
+++ b/tests/berlin/eip2930_access_list/test_tx_intrinsic_gas.py
@@ -29,6 +29,8 @@ REFERENCE_SPEC_VERSION = ref_spec_2930.version
 
 pytestmark = pytest.mark.valid_from("Berlin")
 
+aclSkipReason = "Access lists are not yet supported in the JSON-RPC Relay https://github.com/gkozyryatskyy/execution-spec-tests/issues/6"
+
 tx_intrinsic_gas_data_vectors = [
     pytest.param(Bytes(b""), id="data_empty"),
     pytest.param(Bytes(b"0x00"), id="data_1_zero_byte"),
@@ -74,14 +76,17 @@ tx_intrinsic_gas_access_list_vectors = [
     pytest.param(
         [AccessList(address=1, storage_keys=[])],
         id="access_list_1_address_empty_keys",
+        marks=pytest.mark.skip(reason=aclSkipReason),
     ),
     pytest.param(
         [AccessList(address=1, storage_keys=[0x60A7])],
         id="access_list_1_address_1_keys",
+        marks=pytest.mark.skip(reason=aclSkipReason),
     ),
     pytest.param(
         [AccessList(address=1, storage_keys=[0x60A7, 0x60A8])],
         id="access_list_1_address_2_keys",
+        marks=pytest.mark.skip(reason=aclSkipReason),
     ),
     pytest.param(
         [
@@ -89,6 +94,7 @@ tx_intrinsic_gas_access_list_vectors = [
             AccessList(address=2, storage_keys=[]),
         ],
         id="access_list_2_address_empty_keys",
+        marks=pytest.mark.skip(reason=aclSkipReason),
     ),
     pytest.param(
         [
@@ -96,6 +102,7 @@ tx_intrinsic_gas_access_list_vectors = [
             AccessList(address=2, storage_keys=[0x60A7]),
         ],
         id="access_list_2_address_1_keys",
+        marks=pytest.mark.skip(reason=aclSkipReason),
     ),
     pytest.param(
         [
@@ -103,6 +110,7 @@ tx_intrinsic_gas_access_list_vectors = [
             AccessList(address=2, storage_keys=[0x60A8]),
         ],
         id="access_list_2_address_2_keys",
+        marks=pytest.mark.skip(reason=aclSkipReason),
     ),
     pytest.param(
         [
@@ -110,6 +118,7 @@ tx_intrinsic_gas_access_list_vectors = [
             AccessList(address=2, storage_keys=[]),
         ],
         id="access_list_2_address_2_keys_inversion",
+        marks=pytest.mark.skip(reason=aclSkipReason),
     ),
     pytest.param(
         [
@@ -124,6 +133,7 @@ tx_intrinsic_gas_access_list_vectors = [
             ],
         ],
         id="access_list_12_address_42_keys",
+        marks=pytest.mark.skip(reason=aclSkipReason),
     ),
 ]
 


### PR DESCRIPTION
## 🗒️ Description

This PR enables some tests (that exercise the intrinsic gas costs) in Berlin fork that send empty ACLs.

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
