### PR TITLE
fix: remove stale access list stripping workaround

### DIFF
--- a/src/ethereum_test_types/transaction_types.py
+++ b/src/ethereum_test_types/transaction_types.py
@@ -362,11 +362,6 @@ class Transaction(
         # Set default values for fields that are required for certain tx types
         if self.ty <= 1 and self.gas_price is None:
             self.gas_price = TransactionDefaults.gas_price
-        # NOTICE Sending access list is currently not supported
-        # https://github.com/gkozyryatskyy/execution-spec-tests/issues/6
-        if adjust and self.ty >= 1:
-            self.access_list = []
-
         if self.ty >= 1 and self.access_list is None:
             self.access_list = []
         if self.ty < 1:


### PR DESCRIPTION
## 🗒️ Description

Remove stale workaround that stripped access lists from type 1/2/4 transactions before sending to the Relay (added when the Relay didn't support EIP-2930).

The Relay's `pectra-upgrade` branch now fully supports access lists. With stripping still active, tests setting `gas_limit = intrinsic(with_access_list) - 1` would have their access list zeroed out. The Relay would see a lower intrinsic, accept the tx, and fail the expected rejection check.

EIP-7623 results on Hedera Pectra branches after this fix: **396 passed, 0 failed, 87 skipped** (Type 3 / blob, unsupported on Hedera). Previously: 360 passed, 36 failed.

## 🔗 Related Issues or PRs

Closes https://github.com/gkozyryatskyy/execution-spec-tests/issues/6

Relay PRs that enabled this fix: [#5145](https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/5145), [#5213](https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/5213), [#5271](https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/5271)